### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -36,7 +36,7 @@ print							KEYWORD2
 call_function					KEYWORD2
 print_variable					KEYWORD2
 set_asGlyph						KEYWORD2
-set_asProgmem                   KEYWORD2
+set_asProgmem					KEYWORD2
 
 # class LiquidScreen
 add_line						KEYWORD2
@@ -54,7 +54,7 @@ set_focusSymbol					KEYWORD2
 call_function					KEYWORD2
 update							KEYWORD2
 softUpdate						KEYWORD2
-init                            KEYWORD2
+init							KEYWORD2
 
 # class LiquidSystem
 add_menu						KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords