### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -9,3 +9,4 @@ url=https://github.com/VaSe7u/LiquidMenu
 architectures=avr
 dot_a_linkage=false
 includes=LiquidMenu.h
+depends=LiquidCrystal


### PR DESCRIPTION
### Description
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

`arduino-cli lib install` will automatically install the dependencies (arduino-cli 0.7.0 and newer).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format

### Checklist
- [x] Descriptive pull request title
- [x] Well structured commits
- [x] Consistent style (for new functionality)
- [ ] An example snippet or a full example (for new functionality)
- [ ] Documented interface and commented implementation (for new functionality)
