### PR TITLE
Updated set_focus position and symbol to loop through all menus in the menu system

### DIFF
--- a/src/LiquidSystem.cpp
+++ b/src/LiquidSystem.cpp
@@ -143,10 +143,16 @@ uint8_t LiquidSystem::get_focusedLine() const {
 }
 
 bool LiquidSystem::set_focusPosition(Position position) {
+    for(uint8_t m=0; m<_menuCount; m++) {
+        _p_liquidMenu[m]->set_focusPosition(position);
+    }
 	return _p_liquidMenu[_currentMenu]->set_focusPosition(position);
 }
 
 bool LiquidSystem::set_focusSymbol(Position position, uint8_t symbol[8]) {
+    for(uint8_t m=0; m<_menuCount; m++) {
+        _p_liquidMenu[m]->set_focusSymbol(position, symbol);
+    }
 	return _p_liquidMenu[_currentMenu]->set_focusSymbol(position, symbol);
 }
 


### PR DESCRIPTION
### Description
Presently when setting the focus position and symbol on a menu system, it only updated the current menu. Added a for loop to make the change to all menus. This is logical as the focus is being set on the entire menu system, which implies that it should be set on all menus. (Otherwise it could be set on an individual menu.)

### Checklist
- [ok] Descriptive pull request title
- [ok] Well structured commits
- [ok] Consistent style (for new functionality)
- [unnecessary] An example snippet or a full example (for new functionality)
- [unnecessary] Documented interface and commented implementation (for new functionality)
