### PR TITLE
`LiquidMenu::call_function` method can now be called without updating the display

### DIFF
--- a/src/LiquidMenu.cpp
+++ b/src/LiquidMenu.cpp
@@ -225,9 +225,11 @@ bool LiquidMenu::is_callable(uint8_t number) const {
   return _p_liquidScreen[_currentScreen]->is_callable(number);
 }
 
-bool LiquidMenu::call_function(uint8_t number) const {
+bool LiquidMenu::call_function(uint8_t number, bool refresh) const {
   bool returnValue = _p_liquidScreen[_currentScreen]->call_function(number);
-  update();
+  if (refresh) {
+    update();
+  }
   return returnValue;
 }
 

--- a/src/LiquidMenu.h
+++ b/src/LiquidMenu.h
@@ -989,7 +989,7 @@ public:
 
   @see bool LiquidLine::attach_function(uint8_t number, void (*function)(void))
   */
-  bool call_function(uint8_t number) const;
+  bool call_function(uint8_t number, bool refresh = true) const;
 
   /// Prints the current screen to the display.
   /**


### PR DESCRIPTION
Closes #49.