### PR TITLE
Simplified dynamic text variables.

### DIFF
--- a/examples/C_functions_menu/C_functions_menu.ino
+++ b/examples/C_functions_menu/C_functions_menu.ino
@@ -106,11 +106,14 @@ byte led_level = 0;
 
 // Variables used for setting "preferences".
 bool isFading = false;
-char* isFading_text;
+char isFading_text[4];  // {'O', 'F', 'F', '\0'}
 unsigned int fadePeriod = 100;
 bool isBlinking = false;
-char* isBlinking_text;
+char isBlinking_text[4];
 unsigned int blinkPeriod = 1000;
+
+char string_on[] = "ON";
+char string_off[] = "OFF";
 
 
 LiquidLine welcome_line1(1, 0, "LiquidMenu ", LIQUIDMENU_VERSION);
@@ -154,12 +157,12 @@ void fade_switch() {
 	led_off();
 	if (isFading == true) {
 		isFading = false;
-		isFading_text = (char*)"OFF";
+		strncpy(isFading_text, string_off, sizeof(string_off));
 	} else {
 		isFading = true;
-		isFading_text = (char*)"ON";
+		strncpy(isFading_text, string_on, sizeof(string_on));
 		isBlinking = false;
-		isBlinking_text = (char*)"OFF";
+		strncpy(isBlinking_text, string_off, sizeof(string_off));
 	}
 }
 
@@ -179,12 +182,12 @@ void blink_switch() {
 	led_off();
 	if (isBlinking == true) {
 		isBlinking = false;
-		isBlinking_text = (char*)"OFF";
+		strncpy(isBlinking_text, string_off, sizeof(string_off));
 	} else {
 		isBlinking = true;
-		isBlinking_text = (char*)"ON";
+		strncpy(isBlinking_text, string_on, sizeof(string_on));
 		isFading = false;
-		isFading_text = (char*)"OFF";
+		strncpy(isFading_text, string_off, sizeof(string_off));
 	}
 }
 
@@ -293,8 +296,8 @@ void setup() {
 	menu.add_screen(fade_screen);
 	menu.add_screen(blink_screen);
 
-	isFading_text = (char*)"OFF";
-	isBlinking_text = (char*)"OFF";
+	strncpy(isFading_text, string_off, sizeof(string_off));
+	strncpy(isBlinking_text, string_off, sizeof(string_off));
 
 	menu.update();
 }

--- a/examples/D_buttons_menu/D_buttons_menu.ino
+++ b/examples/D_buttons_menu/D_buttons_menu.ino
@@ -95,10 +95,13 @@ const byte pwmPin = 6;
 byte pwmLevel = 0;
 
 // Variables for controlling a pin and displaying the state with text.
-// char* is used for adding changing text to the LiquidLine object.
+// char[] is used for adding changing text to the LiquidLine object.
 const byte ledPin = LED_BUILTIN;
 bool ledState = LOW;
-char* ledState_text;
+char ledState_text[4];
+
+char string_on[] = "ON";
+char string_off[] = "OFF";
 
 /*
  * Variable 'analogValue' is later configured to be printed on the display.
@@ -162,6 +165,10 @@ void setup() {
 	menu.add_screen(welcome_screen);
 	menu.add_screen(screen2);
 	menu.add_screen(pwm_screen);
+
+	strncpy(ledState_text, string_off, sizeof(string_off));
+
+	menu.update();
 }
 
 void loop() {
@@ -202,12 +209,12 @@ void loop() {
 		if (ledState == LOW) {
 			ledState = HIGH;
 			// Changes the text that is printed on the display.
-			ledState_text = (char*)"ON";
+			strncpy(ledState_text, string_on, sizeof(string_on));
 			Serial.println(ledState_text);
 			menu.update();
 		} else {
 			ledState = LOW;
-			ledState_text = (char*)"OFF";
+			strncpy(ledState_text, string_off, sizeof(string_off));
 			Serial.println(ledState_text);
 			menu.update();
 		}

--- a/examples/H_system_menu/H_system_menu.ino
+++ b/examples/H_system_menu/H_system_menu.ino
@@ -83,8 +83,12 @@ byte pinA5_value = 0;
 unsigned short sample_period = 2;
 
 // Text used for indication for the save lines.
-char* input_saved;
-char* output_saved;
+char input_saved[3];
+char output_saved[3];
+
+char string_saved[] = " *";
+char string_notSaved[] = "  ";
+
 
 enum FunctionTypes {
   increase = 1,
@@ -178,7 +182,7 @@ void increase_pin6() {
     pin6_level = 250;
   }
   analogWrite(pin6, pin6_level);
-  output_saved = (char*)"  ";
+  strncpy(output_saved, string_notSaved, sizeof(string_notSaved));
 }
 
 void decrease_pin6() {
@@ -188,30 +192,30 @@ void decrease_pin6() {
     pin6_level = 0;
   }
   analogWrite(pin6, pin6_level);
-  output_saved = (char*)"  ";
+  strncpy(output_saved, string_notSaved, sizeof(string_notSaved));
 }
 
 void save_input() {
   EEPROM.put(11, sample_period);
-  input_saved = (char*)" *";
+  strncpy(input_saved, string_saved, sizeof(string_saved));
 }
 
 void save_output() {
   EEPROM.put(9, pin6_level);
-  output_saved = (char*)" *";
+  strncpy(output_saved, string_saved, sizeof(string_saved));
 }
 
 void increase_samplePeriod() {
   if (sample_period < 10) {
     sample_period++;
-    input_saved = (char*)"  ";
+    strncpy(input_saved, string_notSaved, sizeof(string_notSaved));
   }
 }
 
 void decrease_samplePeriod() {
   if (sample_period > 0) {
     sample_period--;
-    input_saved = (char*)"  ";
+    strncpy(input_saved, string_notSaved, sizeof(string_notSaved));
   }
 }
 
@@ -247,8 +251,8 @@ void setup() {
   iSample_line.attach_function(increase, increase_samplePeriod);
   iSample_line.attach_function(decrease, decrease_samplePeriod);
 
-  input_saved = (char*)" *";
-  output_saved = (char*)" *";
+  strncpy(input_saved, string_saved, sizeof(string_saved));
+  strncpy(output_saved, string_saved, sizeof(string_saved));
 
   menu_system.update();
 }

--- a/src/LiquidLine.cpp
+++ b/src/LiquidLine.cpp
@@ -146,217 +146,215 @@ void LiquidLine::print(DisplayClass *p_liquidCrystal, bool isFocused) {
 
 void LiquidLine::print_variable(DisplayClass *p_liquidCrystal, uint8_t number) {
 	switch (_variableType[number]) {
-
-    // Variables -----
-	case DataType::CONST_CHAR_PTR: {
-		const char* variable = reinterpret_cast<const char*>(_variable[number]);
-		DEBUG(F("(const char*)")); DEBUG(variable);
-		p_liquidCrystal->print(variable);
-		break;
-	} //case CONST_CHAR_PTR
-	case DataType::CHAR_PTR: {
-		char* variable = *reinterpret_cast<char**>( const_cast<void*>(_variable[number]) );
-		// char* variable = const_cast<char*>(reinterpret_cast<const char *>(_variable[number]));
-		DEBUG(F("(char*)")); DEBUG(variable);
-		p_liquidCrystal->print(variable);
-		break;
-	} //case CHAR_PTR
-	case DataType::CHAR: {
-		const char variable = *static_cast<const char*>(_variable[number]);
-		DEBUG(F("(char)")); DEBUG(variable);
-		p_liquidCrystal->print(variable);
-		break;
-	} //case CHAR
-
-	case DataType::INT8_T: {
-		const int8_t variable = *static_cast<const int8_t*>(_variable[number]);
-		DEBUG(F("(int8_t)")); DEBUG(variable);
-		p_liquidCrystal->print(variable);
-		break;
-	} //case INT8_T
-	case DataType::UINT8_T: {
-		const uint8_t variable = *static_cast<const uint8_t*>(_variable[number]);
-		DEBUG(F("(uint8_t)")); DEBUG(variable);
-		p_liquidCrystal->print(variable);
-		break;
-	} //case UINT8_T
-
-	case DataType::INT16_T: {
-		const int16_t variable = *static_cast<const int16_t*>(_variable[number]);
-		DEBUG(F("(int16_t)")); DEBUG(variable);
-		p_liquidCrystal->print(variable);
-		break;
-	} //case INT16_T
-	case DataType::UINT16_T: {
-		const uint16_t variable = *static_cast<const uint16_t*>(_variable[number]);
-		DEBUG(F("(uint16_t)")); DEBUG(variable);
-		p_liquidCrystal->print(variable);
-		break;
-	} //case UINT16_T
-
-	case DataType::INT32_T: {
-		const int32_t variable = *static_cast<const int32_t*>(_variable[number]);
-		DEBUG(F("(int32_t)")); DEBUG(variable);
-		p_liquidCrystal->print(variable);
-		break;
-	} //case INT32_T
-	case DataType::UINT32_T: {
-		const uint32_t variable = *static_cast<const uint32_t*>(_variable[number]);
-		DEBUG(F("(uint32_t)")); DEBUG(variable);
-		p_liquidCrystal->print(variable);
-		break;
-	} //case UINT32_T
-
-	case DataType::FLOAT: {
-		const float variable = *static_cast<const float*>(_variable[number]);
-		DEBUG(F("(float)")); DEBUG(variable);
-		p_liquidCrystal->print(variable, _floatDecimalPlaces);
-		break;
-	} //case FLOAT
-
-	case DataType::BOOL: {
-		const bool variable = *static_cast<const bool*>(_variable[number]);
-		DEBUG(F("(bool)")); DEBUG(variable);
-		p_liquidCrystal->print(variable);
-		break;
-	} //case BOOL
-
-	case DataType::GLYPH: {
-		const uint8_t variable = *static_cast<const uint8_t*>(_variable[number]);
-		DEBUG(F("(glyph)")); DEBUG(variable);
-		p_liquidCrystal->write((uint8_t)variable);
-		break;
-	} //case BOOL
-
-	case DataType::PROG_CONST_CHAR_PTR: {
-		const char* variable = reinterpret_cast<const char*>(_variable[number]);
-		volatile const int len = strlen_P(variable);
-		char buffer[len];
-		for (uint8_t i = 0; i < len; i++) {
-			buffer[i] = pgm_read_byte_near(variable + i);
-		}
-		buffer[len] = '\0';
-		DEBUG(F("(const char*)")); DEBUG(buffer);
-		p_liquidCrystal->print(buffer);
-		break;
-	} //case PROG_CONST_CHAR_PTR
-    // ~Variables -----
-
-    // Getter functions -----
-	case DataType::CONST_CHAR_PTR_GETTER: {
-		const constcharPtrFnPtr getterFunction = reinterpret_cast<constcharPtrFnPtr>(_variable[number]);
-		if (getterFunction != nullptr) {
-			const char * variable = (getterFunction)();
-		    DEBUG(F("(const char*)")); DEBUG(variable);
+	    // Variables -----
+		case DataType::CONST_CHAR_PTR: {
+			const char* variable = reinterpret_cast<const char*>(_variable[number]);
+			DEBUG(F("(const char*)")); DEBUG(variable);
 			p_liquidCrystal->print(variable);
-		} 
-		break;
-	} // case CONST_CHAR_PTR_GETTER
-
-	case DataType::CHAR_PTR_GETTER: {
-		const charPtrFnPtr getterFunction = reinterpret_cast<charPtrFnPtr>(_variable[number]);
-		if (getterFunction != nullptr) {
-			char* variable = (getterFunction)();
+			break;
+		} //case CONST_CHAR_PTR
+		case DataType::CHAR_PTR: {
+			char* variable = const_cast<char*>(reinterpret_cast<const char *>(_variable[number]));
 			DEBUG(F("(char*)")); DEBUG(variable);
 			p_liquidCrystal->print(variable);
-		} 
-		break;
-	} // case CHAR_PTR_GETTER
-
-	case DataType::CHAR_GETTER: {
-		const charFnPtr getterFunction = reinterpret_cast<charFnPtr>(_variable[number]);
-		if (getterFunction != nullptr) {
-			char variable = (getterFunction)();
+			break;
+		} //case CHAR_PTR
+		case DataType::CHAR: {
+			const char variable = *static_cast<const char*>(_variable[number]);
 			DEBUG(F("(char)")); DEBUG(variable);
 			p_liquidCrystal->print(variable);
-		} 
-		break;
-	} // case CHAR_GETTER
+			break;
+		} //case CHAR
 
-	case DataType::INT8_T_GETTER: {
-		const int8tFnPtr getterFunction = reinterpret_cast<int8tFnPtr>(_variable[number]);
-		if (getterFunction != nullptr) {
-			int8_t variable = (getterFunction)();
+		case DataType::INT8_T: {
+			const int8_t variable = *static_cast<const int8_t*>(_variable[number]);
 			DEBUG(F("(int8_t)")); DEBUG(variable);
 			p_liquidCrystal->print(variable);
-		} 
-		break;
-	} // case INT8_T_GETTER
-
-	case DataType::UINT8_T_GETTER: {
-		const uint8tFnPtr getterFunction = reinterpret_cast<uint8tFnPtr>(_variable[number]);
-		if (getterFunction != nullptr) {
-			uint8_t variable = (getterFunction)();
+			break;
+		} //case INT8_T
+		case DataType::UINT8_T: {
+			const uint8_t variable = *static_cast<const uint8_t*>(_variable[number]);
 			DEBUG(F("(uint8_t)")); DEBUG(variable);
 			p_liquidCrystal->print(variable);
-		} 
-		break;
-	} // case UINT8_T_GETTER
+			break;
+		} //case UINT8_T
 
-	case DataType::INT16_T_GETTER: {
-		const int16tFnPtr getterFunction = reinterpret_cast<int16tFnPtr>(_variable[number]);
-		if (getterFunction != nullptr) {
-			int16_t variable = (getterFunction)();
+		case DataType::INT16_T: {
+			const int16_t variable = *static_cast<const int16_t*>(_variable[number]);
 			DEBUG(F("(int16_t)")); DEBUG(variable);
 			p_liquidCrystal->print(variable);
-		} 
-		break;
-	} // case INT16_T_GETTER
-
-	case DataType::UINT16_T_GETTER: {
-		const uint16tFnPtr getterFunction = reinterpret_cast<uint16tFnPtr>(_variable[number]);
-		if (getterFunction != nullptr) {
-			uint16_t variable = (getterFunction)();
+			break;
+		} //case INT16_T
+		case DataType::UINT16_T: {
+			const uint16_t variable = *static_cast<const uint16_t*>(_variable[number]);
 			DEBUG(F("(uint16_t)")); DEBUG(variable);
 			p_liquidCrystal->print(variable);
-		} 
-		break;
-	} // case UINT16_T_GETTER
+			break;
+		} //case UINT16_T
 
-	case DataType::INT32_T_GETTER: {
-		const int32tFnPtr getterFunction = reinterpret_cast<int32tFnPtr>(_variable[number]);
-		if (getterFunction != nullptr) {
-			int32_t variable = (getterFunction)();
+		case DataType::INT32_T: {
+			const int32_t variable = *static_cast<const int32_t*>(_variable[number]);
 			DEBUG(F("(int32_t)")); DEBUG(variable);
 			p_liquidCrystal->print(variable);
-		} 
-		break;
-	} // case INT32_T_GETTER
-
-	case DataType::UINT32_T_GETTER: {
-		const uint32tFnPtr getterFunction = reinterpret_cast<uint32tFnPtr>(_variable[number]);
-		if (getterFunction != nullptr) {
-			uint32_t variable = (getterFunction)();
+			break;
+		} //case INT32_T
+		case DataType::UINT32_T: {
+			const uint32_t variable = *static_cast<const uint32_t*>(_variable[number]);
 			DEBUG(F("(uint32_t)")); DEBUG(variable);
 			p_liquidCrystal->print(variable);
-		} 
-		break;
-	} // case UINT32_T_GETTER
+			break;
+		} //case UINT32_T
 
-	case DataType::FLOAT_GETTER: {
-		const floatFnPtr getterFunction = reinterpret_cast<floatFnPtr>(_variable[number]);
-		if (getterFunction != nullptr) {
-			const float variable = (getterFunction)();
+		case DataType::FLOAT: {
+			const float variable = *static_cast<const float*>(_variable[number]);
 			DEBUG(F("(float)")); DEBUG(variable);
-			p_liquidCrystal->print(variable);
-		} 
-		break;
-	} // case FLOAT_GETTER
+			p_liquidCrystal->print(variable, _floatDecimalPlaces);
+			break;
+		} //case FLOAT
 
-	case DataType::BOOL_GETTER: {
-		const boolFnPtr getterFunction = reinterpret_cast<boolFnPtr>(_variable[number]);
-		if (getterFunction != nullptr) {
-			bool variable = (getterFunction)();
+		case DataType::BOOL: {
+			const bool variable = *static_cast<const bool*>(_variable[number]);
 			DEBUG(F("(bool)")); DEBUG(variable);
 			p_liquidCrystal->print(variable);
-		} 
-		break;
-	} // case BOOL_GETTER
-    // ~Getter functions -----
+			break;
+		} //case BOOL
 
-	default: { break; }
+		case DataType::GLYPH: {
+			const uint8_t variable = *static_cast<const uint8_t*>(_variable[number]);
+			DEBUG(F("(glyph)")); DEBUG(variable);
+			p_liquidCrystal->write((uint8_t)variable);
+			break;
+		} //case BOOL
 
+		case DataType::PROG_CONST_CHAR_PTR: {
+			const char* variable = reinterpret_cast<const char*>(_variable[number]);
+			volatile const int len = strlen_P(variable);
+			char buffer[len];
+			for (uint8_t i = 0; i < len; i++) {
+				buffer[i] = pgm_read_byte_near(variable + i);
+			}
+			buffer[len] = '\0';
+			DEBUG(F("(const char*)")); DEBUG(buffer);
+			p_liquidCrystal->print(buffer);
+			break;
+		} //case PROG_CONST_CHAR_PTR
+	    // ~Variables -----
+
+	    // Getter functions -----
+		case DataType::CONST_CHAR_PTR_GETTER: {
+			const constcharPtrFnPtr getterFunction = reinterpret_cast<constcharPtrFnPtr>(_variable[number]);
+			if (getterFunction != nullptr) {
+				const char * variable = (getterFunction)();
+			    DEBUG(F("(const char*)")); DEBUG(variable);
+				p_liquidCrystal->print(variable);
+			} 
+			break;
+		} // case CONST_CHAR_PTR_GETTER
+
+		case DataType::CHAR_PTR_GETTER: {
+			const charPtrFnPtr getterFunction = reinterpret_cast<charPtrFnPtr>(_variable[number]);
+			if (getterFunction != nullptr) {
+				char* variable = (getterFunction)();
+				DEBUG(F("(char*)")); DEBUG(variable);
+				p_liquidCrystal->print(variable);
+			} 
+			break;
+		} // case CHAR_PTR_GETTER
+
+		case DataType::CHAR_GETTER: {
+			const charFnPtr getterFunction = reinterpret_cast<charFnPtr>(_variable[number]);
+			if (getterFunction != nullptr) {
+				char variable = (getterFunction)();
+				DEBUG(F("(char)")); DEBUG(variable);
+				p_liquidCrystal->print(variable);
+			} 
+			break;
+		} // case CHAR_GETTER
+
+		case DataType::INT8_T_GETTER: {
+			const int8tFnPtr getterFunction = reinterpret_cast<int8tFnPtr>(_variable[number]);
+			if (getterFunction != nullptr) {
+				int8_t variable = (getterFunction)();
+				DEBUG(F("(int8_t)")); DEBUG(variable);
+				p_liquidCrystal->print(variable);
+			} 
+			break;
+		} // case INT8_T_GETTER
+
+		case DataType::UINT8_T_GETTER: {
+			const uint8tFnPtr getterFunction = reinterpret_cast<uint8tFnPtr>(_variable[number]);
+			if (getterFunction != nullptr) {
+				uint8_t variable = (getterFunction)();
+				DEBUG(F("(uint8_t)")); DEBUG(variable);
+				p_liquidCrystal->print(variable);
+			} 
+			break;
+		} // case UINT8_T_GETTER
+
+		case DataType::INT16_T_GETTER: {
+			const int16tFnPtr getterFunction = reinterpret_cast<int16tFnPtr>(_variable[number]);
+			if (getterFunction != nullptr) {
+				int16_t variable = (getterFunction)();
+				DEBUG(F("(int16_t)")); DEBUG(variable);
+				p_liquidCrystal->print(variable);
+			} 
+			break;
+		} // case INT16_T_GETTER
+
+		case DataType::UINT16_T_GETTER: {
+			const uint16tFnPtr getterFunction = reinterpret_cast<uint16tFnPtr>(_variable[number]);
+			if (getterFunction != nullptr) {
+				uint16_t variable = (getterFunction)();
+				DEBUG(F("(uint16_t)")); DEBUG(variable);
+				p_liquidCrystal->print(variable);
+			} 
+			break;
+		} // case UINT16_T_GETTER
+
+		case DataType::INT32_T_GETTER: {
+			const int32tFnPtr getterFunction = reinterpret_cast<int32tFnPtr>(_variable[number]);
+			if (getterFunction != nullptr) {
+				int32_t variable = (getterFunction)();
+				DEBUG(F("(int32_t)")); DEBUG(variable);
+				p_liquidCrystal->print(variable);
+			} 
+			break;
+		} // case INT32_T_GETTER
+
+		case DataType::UINT32_T_GETTER: {
+			const uint32tFnPtr getterFunction = reinterpret_cast<uint32tFnPtr>(_variable[number]);
+			if (getterFunction != nullptr) {
+				uint32_t variable = (getterFunction)();
+				DEBUG(F("(uint32_t)")); DEBUG(variable);
+				p_liquidCrystal->print(variable);
+			} 
+			break;
+		} // case UINT32_T_GETTER
+
+		case DataType::FLOAT_GETTER: {
+			const floatFnPtr getterFunction = reinterpret_cast<floatFnPtr>(_variable[number]);
+			if (getterFunction != nullptr) {
+				const float variable = (getterFunction)();
+				DEBUG(F("(float)")); DEBUG(variable);
+				p_liquidCrystal->print(variable);
+			} 
+			break;
+		} // case FLOAT_GETTER
+
+		case DataType::BOOL_GETTER: {
+			const boolFnPtr getterFunction = reinterpret_cast<boolFnPtr>(_variable[number]);
+			if (getterFunction != nullptr) {
+				bool variable = (getterFunction)();
+				DEBUG(F("(bool)")); DEBUG(variable);
+				p_liquidCrystal->print(variable);
+			} 
+			break;
+		} // case BOOL_GETTER
+	    // ~Getter functions -----
+
+		default: { break; }
 	} //switch (_variableType)
+
 	DEBUG(F(" "));
 }
 


### PR DESCRIPTION
Usage of dynamic text as a variable for `LiquidLine` object is simplified.
Resolves #12 and #41.

Character array variables inside `LiquidLine` objects are now correctly "casted" back for printing. Previous usage required creating and passing a `char*` to `LiquidLine` and pointing that variable to the actual text. Current usage allows passing a character array directly as a variable to `LiquidLine` objects and changing its value directly (using `strncpy`).
